### PR TITLE
Enable scriptable render pipeline support for Blink Teleport Provider

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/LocomotionSystem/BlinkTeleportLocomotionProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/LocomotionSystem/BlinkTeleportLocomotionProviderProfileInspector.cs
@@ -10,12 +10,18 @@ namespace XRTK.Editor.Profiles.LocomotionSystem
     public class BlinkTeleportLocomotionProviderProfileInspector : BaseTeleportLocomotionProviderProfileInspector
     {
         private SerializedProperty fadeDuration;
+        private SerializedProperty fadeMaterial;
+        private SerializedProperty fadeInColor;
+        private SerializedProperty fadeOutColor;
 
         protected override void OnEnable()
         {
             base.OnEnable();
 
             fadeDuration = serializedObject.FindProperty(nameof(fadeDuration));
+            fadeMaterial = serializedObject.FindProperty(nameof(fadeMaterial));
+            fadeInColor = serializedObject.FindProperty(nameof(fadeInColor));
+            fadeOutColor = serializedObject.FindProperty(nameof(fadeOutColor));
         }
 
         public override void OnInspectorGUI()
@@ -25,6 +31,9 @@ namespace XRTK.Editor.Profiles.LocomotionSystem
             serializedObject.Update();
 
             EditorGUILayout.PropertyField(fadeDuration);
+            EditorGUILayout.PropertyField(fadeMaterial);
+            EditorGUILayout.PropertyField(fadeInColor);
+            EditorGUILayout.PropertyField(fadeOutColor);
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/LocomotionSystem/BlinkTeleportLocomotionProviderProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/LocomotionSystem/BlinkTeleportLocomotionProviderProfile.cs
@@ -22,5 +22,44 @@ namespace XRTK.Definitions.LocomotionSystem
             get => fadeDuration;
             internal set => fadeDuration = value;
         }
+
+        [SerializeField]
+        [Tooltip("The material used to simulate a blink.")]
+        private Material fadeMaterial = null;
+
+        /// <summary>
+        /// The material used to simulate a blink.
+        /// </summary>
+        public Material FadeMaterial
+        {
+            get => fadeMaterial;
+            internal set => fadeMaterial = value;
+        }
+
+        [SerializeField]
+        [Tooltip("The color applied gradually when fading back in after a teleport.")]
+        private Color fadeInColor = Color.clear;
+
+        /// <summary>
+        /// The color applied gradually when fading back in after a teleport.
+        /// </summary>
+        public Color FadeInColor
+        {
+            get => fadeInColor;
+            internal set => fadeInColor = value;
+        }
+
+        [SerializeField]
+        [Tooltip("The color applied gradually when fading out before a teleport.")]
+        private Color fadeOutColor = Color.black;
+
+        /// <summary>
+        /// The color applied gradually when fading out before a teleport.
+        /// </summary>
+        public Color FadeOutColor
+        {
+            get => fadeOutColor;
+            internal set => fadeOutColor = value;
+        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/LocomotionSystem/BlinkTeleportLocomotionProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/LocomotionSystem/BlinkTeleportLocomotionProvider.cs
@@ -7,7 +7,6 @@ using XRTK.Extensions;
 using XRTK.Definitions.LocomotionSystem;
 using XRTK.Interfaces.LocomotionSystem;
 using XRTK.Services.LocomotionSystem;
-using XRTK.Utilities;
 using XRTK.Interfaces.InputSystem;
 using XRTK.Definitions.Utilities;
 
@@ -26,20 +25,20 @@ namespace XRTK.Providers.LocomotionSystem
             : base(name, priority, profile, parentService)
         {
             fadeDuration = profile.FadeDuration;
+            fadeMaterial = profile.FadeMaterial;
+            fadeInColor = profile.FadeInColor;
+            fadeOutColor = profile.FadeOutColor;
         }
 
-        private static readonly int sourceBlend = Shader.PropertyToID("_SrcBlend");
-        private static readonly int destinationBlend = Shader.PropertyToID("_DstBlend");
-        private static readonly int zWrite = Shader.PropertyToID("_ZWrite");
-
         private readonly float fadeDuration;
+        private readonly Material fadeMaterial;
+        private readonly Color fadeInColor;
+        private readonly Color fadeOutColor;
         private IMixedRealityInputSource inputSource;
         private MixedRealityPose targetPose;
         private ITeleportAnchor targetAnchor;
         private GameObject fadeSphere;
         private MeshRenderer fadeSphereRenderer;
-        private Color fadeInColor = Color.clear;
-        private Color fadeOutColor = Color.black;
         private bool isFadingOut;
         private bool isFadingIn;
         private float fadeTime;
@@ -215,30 +214,6 @@ namespace XRTK.Providers.LocomotionSystem
                 fadeSphereRenderer.allowOcclusionWhenDynamic = false;
                 fadeSphereRenderer.lightProbeUsage = LightProbeUsage.Off;
                 fadeSphereRenderer.reflectionProbeUsage = ReflectionProbeUsage.Off;
-
-                // Finally paint the sphere with a transparency enabled material.
-                // We use the default material created on the sphere to clone its properties.
-                var fadeMaterial = new Material(fadeSphereRenderer.material)
-                {
-                    color = fadeInColor
-                };
-
-                if (RenderPipelineUtilities.GetActiveRenderingPipeline() == Definitions.Utilities.RenderPipeline.Legacy)
-                {
-                    // Unity standard shader can be assumed since we created a primitive.
-                    fadeMaterial.SetInt(sourceBlend, (int)BlendMode.One);
-                    fadeMaterial.SetInt(destinationBlend, (int)BlendMode.OneMinusSrcAlpha);
-                    fadeMaterial.SetInt(zWrite, 0);
-                    fadeMaterial.DisableKeyword("_ALPHATEST_ON");
-                    fadeMaterial.DisableKeyword("_ALPHABLEND_ON");
-                    fadeMaterial.EnableKeyword("_ALPHAPREMULTIPLY_ON");
-                    fadeMaterial.renderQueue = 3000;
-                }
-                else
-                {
-                    Debug.LogError($"{nameof(BlinkTeleportLocomotionProvider)} does not support render pipelines. The provider won't be able to fade in and out.");
-                }
-
                 fadeSphereRenderer.material = fadeMaterial;
             }
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

I need the blink teleport provider to support scriptable render pipelines. In the legacy pipeline it was possible to change a materials properties to support transparency at runtime. With render pipelines this is not possible anymore for performance reasons (they said). So I made the material used for blinking a configurable setting in the provider's profile, which is useful in many ways anyways. Also exposed two more settings that were hardwired in the provider previously.

![image](https://user-images.githubusercontent.com/9565734/135518154-e23b19ea-46a0-4fbe-b865-fdf5a0b9017d.png)


## Changes

- Exposed fade material and colors as settings in the blink teleport provider profile

## Related Submodule Changes

- https://github.com/XRTK/com.xrtk.sdk/pull/246