### PR TITLE
Fix camera rig component added to camera and rig transform

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
@@ -152,13 +152,11 @@ namespace XRTK.Providers.CameraSystem
             {
                 if (CameraCache.Main.transform.parent.IsNull())
                 {
-                    CameraRig = CameraCache.Main.gameObject.EnsureComponent(cameraRigType) as IMixedRealityCameraRig;
-                }
-                else
-                {
-                    CameraRig = CameraCache.Main.transform.parent.gameObject.EnsureComponent(cameraRigType) as IMixedRealityCameraRig;
+                    var rigTransform = new GameObject().transform;
+                    CameraCache.Main.transform.SetParent(rigTransform);
                 }
 
+                CameraRig = CameraCache.Main.transform.parent.gameObject.EnsureComponent(cameraRigType) as IMixedRealityCameraRig;
                 Debug.Assert(CameraRig != null);
             }
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Fixes a small issue introduced with #898 where the `Camera Rig Component` was added to the Rig root transform AND the camera transform itself.