### PR TITLE
Make use of existing event system setup if available

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/InputSystem/MixedRealityInputSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/InputSystem/MixedRealityInputSystem.cs
@@ -112,39 +112,13 @@ namespace XRTK.Services.InputSystem
         {
             base.Initialize();
 
-            bool addedComponents = false;
+            EnsureStandaloneInputModuleSetup();
 
             if (!Application.isPlaying)
             {
-                var standaloneInputModules = UnityEngine.Object.FindObjectsOfType<StandaloneInputModule>();
-
                 var cameraTransform = CameraCache.Main.transform;
                 cameraTransform.position = Vector3.zero;
                 cameraTransform.rotation = Quaternion.identity;
-
-                if (standaloneInputModules.Length == 0)
-                {
-                    CameraCache.Main.gameObject.EnsureComponent<StandaloneInputModule>();
-                    addedComponents = true;
-                }
-                else
-                {
-                    bool raiseWarning;
-
-                    if (standaloneInputModules.Length == 1)
-                    {
-                        raiseWarning = standaloneInputModules[0].gameObject != CameraCache.Main.gameObject;
-                    }
-                    else
-                    {
-                        raiseWarning = true;
-                    }
-
-                    if (raiseWarning)
-                    {
-                        Debug.LogWarning("Found an existing Standalone Input Module in your scene. The Mixed Reality Input System requires only one, and must be found on the main camera.");
-                    }
-                }
             }
             else
             {
@@ -174,12 +148,21 @@ namespace XRTK.Services.InputSystem
                 dictationEventData = new DictationEventData(eventSystem);
             }
 
-            if (!addedComponents)
+            GazeProvider = CameraCache.Main.gameObject.EnsureComponent(gazeProviderType) as IMixedRealityGazeProvider;
+        }
+
+        private void EnsureStandaloneInputModuleSetup()
+        {
+            var standaloneInputModules = UnityEngine.Object.FindObjectsOfType<StandaloneInputModule>();
+            if (standaloneInputModules.Length == 0)
             {
                 CameraCache.Main.gameObject.EnsureComponent<StandaloneInputModule>();
+                Debug.Log($"There was no {nameof(StandaloneInputModule)} in the scene. The {nameof(MixedRealityInputSystem)} requires one and added it to the main camera.");
             }
-
-            GazeProvider = CameraCache.Main.gameObject.EnsureComponent(gazeProviderType) as IMixedRealityGazeProvider;
+            else if (standaloneInputModules.Length > 1)
+            {
+                Debug.LogError($"There is more than one {nameof(StandaloneInputModule)} active in the scene. Please make sure only one instance of it exists as it may cause errors.");
+            }
         }
 
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
@@ -530,40 +530,21 @@ namespace XRTK.Services
             // We'll enforce that here, then tracking can update it to the appropriate position later.
             CameraCache.Main.transform.position = Vector3.zero;
 
-            bool addedComponents = false;
+            // We need at least one instance of the event system to be active.
+            EnsureEventSystemSetup();
+        }
 
-            if (!Application.isPlaying)
-            {
-                var eventSystems = FindObjectsOfType<EventSystem>();
-
-                if (eventSystems.Length == 0)
-                {
-                    CameraCache.Main.gameObject.EnsureComponent<EventSystem>();
-                    addedComponents = true;
-                }
-                else
-                {
-                    bool raiseWarning;
-
-                    if (eventSystems.Length == 1)
-                    {
-                        raiseWarning = eventSystems[0].gameObject != CameraCache.Main.gameObject;
-                    }
-                    else
-                    {
-                        raiseWarning = true;
-                    }
-
-                    if (raiseWarning)
-                    {
-                        Debug.LogWarning($"Found an existing event system in your scene. The {nameof(MixedRealityToolkit)} requires only one, and must be found on the main camera.");
-                    }
-                }
-            }
-
-            if (!addedComponents)
+        private static void EnsureEventSystemSetup()
+        {
+            var eventSystems = FindObjectsOfType<EventSystem>();
+            if (eventSystems.Length == 0)
             {
                 CameraCache.Main.gameObject.EnsureComponent<EventSystem>();
+                Debug.Log($"There was no {nameof(EventSystem)} in the scene. The {nameof(MixedRealityToolkit)} requires one and added it to the main camera.");
+            }
+            else if (eventSystems.Length > 1)
+            {
+                Debug.LogError($"There is more than one {nameof(EventSystem)} active in the scene. Please make sure only one instance of it exists as it may cause errors.");
             }
         }
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Updated requirements check behavior. The toolkit will add an `EventSystem` / `StandaloneInputModule` only if needed. If the developer has a custom setup it will leave it alone. The toolkit will raise errors if multiple instances of either exist.