### PR TITLE
Exposed frame diagnostics for third party consumption

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Interfaces/DiagnosticsSystem/IMixedRealityFrameDiagnosticsDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Interfaces/DiagnosticsSystem/IMixedRealityFrameDiagnosticsDataProvider.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace XRTK.Interfaces.DiagnosticsSystem
+{
+    public interface IMixedRealityFrameDiagnosticsDataProvider : IMixedRealityDiagnosticsDataProvider
+    {
+        /// <summary>
+        /// The last computed GPU frame rate.
+        /// </summary>
+        int GPUFrameRate { get; }
+
+        /// <summary>
+        /// The last computed CPU frame rate.
+        /// </summary>
+        int CPUFrameRate { get; }
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Interfaces/DiagnosticsSystem/IMixedRealityFrameDiagnosticsDataProvider.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Interfaces/DiagnosticsSystem/IMixedRealityFrameDiagnosticsDataProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27ac92b111d08f34c8dcee0db2400013
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/DiagnosticsSystem/MixedRealityFrameDiagnosticsDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/DiagnosticsSystem/MixedRealityFrameDiagnosticsDataProvider.cs
@@ -13,7 +13,7 @@ namespace XRTK.Services.DiagnosticsSystem
     /// information to identify performance issues.
     /// </summary>
     [System.Runtime.InteropServices.Guid("1B5E5A67-864C-4A3D-A099-5A46EAD399A8")]
-    public class MixedRealityFrameDiagnosticsDataProvider : BaseMixedRealityDiagnosticsDataProvider
+    public class MixedRealityFrameDiagnosticsDataProvider : BaseMixedRealityDiagnosticsDataProvider, IMixedRealityFrameDiagnosticsDataProvider
     {
         /// <inheritdoc />
         public MixedRealityFrameDiagnosticsDataProvider(string name, uint priority, BaseMixedRealityProfile profile, IMixedRealityDiagnosticsSystem parentService)
@@ -49,15 +49,11 @@ namespace XRTK.Services.DiagnosticsSystem
             }
         }
 
-        /// <summary>
-        /// The last computed GPU frame rate.
-        /// </summary>
-        private int GPUFrameRate { get; set; } = 0;
+        /// <inheritdoc />
+        public int GPUFrameRate { get; set; } = 0;
 
-        /// <summary>
-        /// The last computed CPU frame rate.
-        /// </summary>
-        private int CPUFrameRate { get; set; } = 0;
+        /// <inheritdoc />
+        public int CPUFrameRate { get; set; } = 0;
 
         /// <summary>
         /// Computed property returns the target refresh rate of the device,


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Introduced `IMixedRealityFrameDiagnosticsDataProvider` and exposed frame diagnostics so they can be read by third party implementations for custom logging etc. without relying on the diagnostics window.
