### PR TITLE
Implement tracking type configuration for camera data providers

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/BaseMixedRealityCameraDataProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/BaseMixedRealityCameraDataProviderProfileInspector.cs
@@ -12,6 +12,7 @@ namespace XRTK.Editor.Profiles.CameraSystem
     [CustomEditor(typeof(BaseMixedRealityCameraDataProviderProfile), true, isFallback = true)]
     public class BaseMixedRealityCameraDataProviderProfileInspector : BaseMixedRealityProfileInspector
     {
+        private SerializedProperty trackingType;
         private SerializedProperty trackingOriginMode;
         private SerializedProperty isCameraPersistent;
         private SerializedProperty applyQualitySettings;
@@ -41,6 +42,7 @@ namespace XRTK.Editor.Profiles.CameraSystem
         {
             base.OnEnable();
 
+            trackingType = serializedObject.FindProperty(nameof(trackingType));
             trackingOriginMode = serializedObject.FindProperty(nameof(trackingOriginMode));
             isCameraPersistent = serializedObject.FindProperty(nameof(isCameraPersistent));
             applyQualitySettings = serializedObject.FindProperty(nameof(applyQualitySettings));
@@ -69,9 +71,10 @@ namespace XRTK.Editor.Profiles.CameraSystem
 
             EditorGUI.BeginChangeCheck();
 
-            if (trackingOriginMode.FoldoutWithBoldLabelPropertyField(platformSettingsFoldoutHeader))
+            if (trackingType.FoldoutWithBoldLabelPropertyField(platformSettingsFoldoutHeader))
             {
                 EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(trackingOriginMode);
                 EditorGUILayout.PropertyField(isCameraPersistent);
                 EditorGUILayout.PropertyField(cameraRigType);
                 EditorGUILayout.PropertyField(defaultHeadHeight);

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/CameraSystem/BaseMixedRealityCameraDataProviderProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/CameraSystem/BaseMixedRealityCameraDataProviderProfile.cs
@@ -17,6 +17,15 @@ namespace XRTK.Definitions.CameraSystem
     public class BaseMixedRealityCameraDataProviderProfile : BaseMixedRealityProfile
     {
         [SerializeField]
+        [Tooltip("Sets the tracking type of the camera.")]
+        private TrackingType trackingType = TrackingType.Auto;
+
+        /// <summary>
+        /// The configured tracking type of the camera.
+        /// </summary>
+        public TrackingType TrackingType => trackingType;
+
+        [SerializeField]
         [Tooltip("Sets the type of tracking origin to use for this Rig. Tracking origins identify where 0,0,0 is in the world of tracking.")]
         private TrackingOriginModeFlags trackingOriginMode = TrackingOriginModeFlags.Unknown;
 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Interfaces/CameraSystem/IMixedRealityCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Interfaces/CameraSystem/IMixedRealityCameraDataProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using XRTK.Services.CameraSystem;
+
 namespace XRTK.Interfaces.CameraSystem
 {
     /// <summary>
@@ -31,6 +33,11 @@ namespace XRTK.Interfaces.CameraSystem
         /// The <see cref="IMixedRealityCameraRig"/> reference for this data provider.
         /// </summary>
         IMixedRealityCameraRig CameraRig { get; }
+
+        /// <summary>
+        /// The <see cref="Services.CameraSystem.TrackingType"/> this provider is configured to use.
+        /// </summary>
+        TrackingType TrackingType { get; }
 
 #if XRTK_USE_LEGACYVR
         /// <summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Interfaces/CameraSystem/IMixedRealityCameraSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Interfaces/CameraSystem/IMixedRealityCameraSystem.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
+using XRTK.Services.CameraSystem;
 
 namespace XRTK.Interfaces.CameraSystem
 {
@@ -19,6 +20,11 @@ namespace XRTK.Interfaces.CameraSystem
         /// The reference to the <see cref="IMixedRealityCameraRig"/> attached to the Main Camera (typically this is the player's camera).
         /// </summary>
         IMixedRealityCameraRig MainCameraRig { get; }
+
+        /// <summary>
+        /// Gets the configured <see cref="TrackingType"/> for the active <see cref="IMixedRealityCameraRig"/>.
+        /// </summary>
+        TrackingType TrackingType { get; }
 
 #if XRTK_USE_LEGACYVR
         /// <summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
@@ -8,6 +8,7 @@ using XRTK.Extensions;
 using XRTK.Interfaces.CameraSystem;
 using XRTK.Services;
 using XRTK.Utilities;
+using XRTK.Services.CameraSystem;
 
 #if !XRTK_USE_LEGACYVR
 using UnityEngine.XR;
@@ -43,6 +44,8 @@ namespace XRTK.Providers.CameraSystem
             isCameraPersistent = profile.IsCameraPersistent;
             cameraRigType = profile.CameraRigType.Type;
             applyQualitySettings = profile.ApplyQualitySettings;
+
+            TrackingType = profile.TrackingType;
 
 #if XRTK_USE_LEGACYVR
             DefaultHeadHeight = profile.DefaultHeadHeight;
@@ -107,6 +110,9 @@ namespace XRTK.Providers.CameraSystem
 
         /// <inheritdoc />
         public IMixedRealityCameraRig CameraRig { get; private set; }
+
+        /// <inheritdoc />
+        public TrackingType TrackingType { get; }
 
 #if XRTK_USE_LEGACYVR
         /// <inheritdoc />

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
@@ -155,6 +155,7 @@ namespace XRTK.Services.CameraSystem
                 }
 
                 cameraPoseDriver = PlayerCamera.gameObject.EnsureComponent<TrackedPoseDriver>();
+
 #if XRTK_USE_LEGACYVR
                 cameraPoseDriver.UseRelativeTransform = true;
 #else
@@ -203,6 +204,28 @@ namespace XRTK.Services.CameraSystem
         #endregion IMixedRealityCameraRig Implementation
 
         #region MonoBehaviour Implementation
+
+        private void Start()
+        {
+            if (MixedRealityToolkit.TryGetSystem<IMixedRealityCameraSystem>(out var cameraSystem)
+                && CameraPoseDriver.IsNotNull())
+            {
+                switch (cameraSystem.TrackingType)
+                {
+                    case TrackingType.SixDegreesOfFreedom:
+                        CameraPoseDriver.trackingType = TrackedPoseDriver.TrackingType.RotationAndPosition;
+                        break;
+                    case TrackingType.ThreeDegreesOfFreedom:
+                        CameraPoseDriver.trackingType = TrackedPoseDriver.TrackingType.RotationOnly;
+                        break;
+                    case TrackingType.Auto:
+                    default:
+                        // For now, leave whatever the user has confitured manually on the component. Once we
+                        // have APIs in place to querey platform capabilities, we might use that for auto.
+                        break;
+                }
+            }
+        }
 
         private void OnValidate()
         {

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/MixedRealityCameraSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/MixedRealityCameraSystem.cs
@@ -65,6 +65,25 @@ namespace XRTK.Services.CameraSystem
             }
         }
 
+        /// <inheritdoc />
+        public TrackingType TrackingType
+        {
+            get
+            {
+                foreach (var dataProvider in cameraDataProviders)
+                {
+                    if (dataProvider.CameraRig.PlayerCamera == CameraCache.Main)
+                    {
+                        return dataProvider.TrackingType;
+                    }
+                }
+
+                // If we can't find the active camera data provider we must rely
+                // on whatever the platform default is.
+                return TrackingType.Auto;
+            }
+        }
+
 #if XRTK_USE_LEGACYVR
         /// <inheritdoc />
         public void SetHeadHeight(float value, bool setForAllCameraProviders = false)

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/TrackingType.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/TrackingType.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) XRTK. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace XRTK.Services.CameraSystem
+{
+    /// <summary>
+    /// Available tracking types for the camera operated by the <see cref="Interfaces.CameraSystem.IMixedRealityCameraSystem"/>.
+    /// </summary>
+    public enum TrackingType
+    {
+        /// <summary>
+        /// Use platform defaults or if applicable, auto determine the supported
+        /// <see cref="TrackingType"/> by the device running the application.
+        /// </summary>
+        Auto = 0,
+        /// <summary>
+        /// Positional and orientational tracking.
+        /// </summary>
+        SixDegreesOfFreedom,
+        /// <summary>
+        /// Orientational tracking only.
+        /// </summary>
+        ThreeDegreesOfFreedom
+    }
+}

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/TrackingType.cs.meta
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/TrackingType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07cfdbba9a119204ba6b9b742f1d9895
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Implements a new `TrackingType` setting for camera data providers. It allows whether the camera rig should operate in 3DOF or 6DOF mode.

Scenario: A device supports 6DOF tracking but the developer wants it to not make use of it and use 3DOF instead.