### PR TITLE
Implement eyeTextureResolution setting for camera data providers

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/BaseMixedRealityCameraDataProviderProfileInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/Profiles/BaseMixedRealityCameraDataProviderProfileInspector.cs
@@ -14,6 +14,7 @@ namespace XRTK.Editor.Profiles.CameraSystem
     {
         private SerializedProperty trackingType;
         private SerializedProperty trackingOriginMode;
+        private SerializedProperty eyeTextureResolution;
         private SerializedProperty isCameraPersistent;
         private SerializedProperty applyQualitySettings;
 
@@ -44,6 +45,7 @@ namespace XRTK.Editor.Profiles.CameraSystem
 
             trackingType = serializedObject.FindProperty(nameof(trackingType));
             trackingOriginMode = serializedObject.FindProperty(nameof(trackingOriginMode));
+            eyeTextureResolution = serializedObject.FindProperty(nameof(eyeTextureResolution));
             isCameraPersistent = serializedObject.FindProperty(nameof(isCameraPersistent));
             applyQualitySettings = serializedObject.FindProperty(nameof(applyQualitySettings));
 
@@ -75,6 +77,7 @@ namespace XRTK.Editor.Profiles.CameraSystem
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(trackingOriginMode);
+                EditorGUILayout.PropertyField(eyeTextureResolution);
                 EditorGUILayout.PropertyField(isCameraPersistent);
                 EditorGUILayout.PropertyField(cameraRigType);
                 EditorGUILayout.PropertyField(defaultHeadHeight);

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/CameraSystem/BaseMixedRealityCameraDataProviderProfile.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Definitions/CameraSystem/BaseMixedRealityCameraDataProviderProfile.cs
@@ -35,6 +35,17 @@ namespace XRTK.Definitions.CameraSystem
         public TrackingOriginModeFlags TrackingOriginMode => trackingOriginMode;
 
         [SerializeField]
+        [Range(1f, 2f)]
+        [Tooltip("Rendered eye texture resolution. A value greater than 1 has an impact on performance.")]
+        private float eyeTextureResolution = 1f;
+
+        /// <summary>
+        /// Rendered eye texture resolution. A value greater than 1 has
+        /// an impact on performance.
+        /// </summary>
+        public float EyeTextureResolution => eyeTextureResolution;
+
+        [SerializeField]
         private bool isCameraPersistent = true;
 
         /// <summary>

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
@@ -41,6 +41,7 @@ namespace XRTK.Providers.CameraSystem
                 throw new Exception($"{nameof(profile.CameraRigType)} cannot be null!");
             }
 
+            eyeTextureResolution = profile.EyeTextureResolution;
             isCameraPersistent = profile.IsCameraPersistent;
             cameraRigType = profile.CameraRigType.Type;
             applyQualitySettings = profile.ApplyQualitySettings;
@@ -69,6 +70,7 @@ namespace XRTK.Providers.CameraSystem
         }
 
         private readonly IMixedRealityCameraSystem cameraSystem;
+        private readonly float eyeTextureResolution;
         private readonly bool isCameraPersistent;
         private readonly Type cameraRigType;
         private readonly bool applyQualitySettings;
@@ -191,6 +193,11 @@ namespace XRTK.Providers.CameraSystem
             }
 
             cameraSystem.RegisterCameraDataProvider(this);
+
+            if (Application.isPlaying)
+            {
+                XRSettings.eyeTextureResolutionScale = eyeTextureResolution;
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Added ` eyeTextureResolution` setting to `BaseCameraDataProvider` profile and implementation to apply to the `XRSettings.eyeTextureResolutionScale` Unity setting. This is useful when targeting multiple platforms and the camera needs scale differently. In my use case

- Meta Quest -> texture scale 2
- Pico -> texture scale 1