### PR TITLE
Remove hard coded default head heigth value

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
@@ -52,7 +52,7 @@ namespace XRTK.Providers.CameraSystem
             DefaultHeadHeight = profile.DefaultHeadHeight;
 #else
             trackingOriginMode = profile.TrackingOriginMode;
-            defaultHeadHeight = profile.DefaultHeadHeight > 0f ? profile.DefaultHeadHeight : 1.6f;
+            defaultHeadHeight = profile.DefaultHeadHeight;
 #endif
 
             nearClipPlaneOpaqueDisplay = profile.NearClipPlaneOpaqueDisplay;


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Removed the hard-coded default head height value `1.6`. The initial idea here was back then to have a reasonable default head height in case the profile value is `0`. As it turns out this was a mistake, some people WANT explicitly to have 0 as the default head height, e.g. when using Tracking Origin Mode `Device`, which was recently introduced as a setting to the camera system.
