### PR TITLE
Remove cached symlink files which can cause errors on fresh clones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ XRTK-Core/Assets/Plugins/Lumin/Editor/
 XRTK-Core/Assets/Plugins/Lumin/Editor.meta
 XRTK-Core/Assets/StreamingAssets/
 XRTK-Core/Assets/StreamingAssets.meta
+XRTK-Core/Assets/XRTK.Generated
+XRTK-Core/Assets/XRTK.Examples
+XRTK-Core/Assets/XRTK.Examples.meta

--- a/XRTK-Core/Assets/XRTK.Examples
+++ b/XRTK-Core/Assets/XRTK.Examples
@@ -1,1 +1,0 @@
-../../Submodules/Examples/XRTK.Examples/Assets/XRTK.Examples

--- a/XRTK-Core/Assets/XRTK.Examples.meta
+++ b/XRTK-Core/Assets/XRTK.Examples.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 1b66c1cc597e22d459cc844f8a9cf87c
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/XRTK-Core/Assets/XRTK.Generated/Lumin.meta
+++ b/XRTK-Core/Assets/XRTK.Generated/Lumin.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3ac1a6fb034a1314faa0698b5545a93e
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/XRTK-Core/Assets/XRTK.Generated/Lumin/Profiles
+++ b/XRTK-Core/Assets/XRTK.Generated/Lumin/Profiles
@@ -1,1 +1,0 @@
-../../../../Submodules/Lumin/XRTK.Lumin/Packages/com.xrtk.lumin/Profiles~

--- a/XRTK-Core/Assets/XRTK.Generated/Lumin/Profiles.meta
+++ b/XRTK-Core/Assets/XRTK.Generated/Lumin/Profiles.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 1c2e591cf71dd0b40bb6327088975737
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/XRTK-Core/Assets/XRTK.Generated/Oculus.meta
+++ b/XRTK-Core/Assets/XRTK.Generated/Oculus.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 73ba5bfb59ce69c4db610c504a10ab08
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/XRTK-Core/Assets/XRTK.Generated/Oculus/Profiles
+++ b/XRTK-Core/Assets/XRTK.Generated/Oculus/Profiles
@@ -1,1 +1,0 @@
-../../../../Submodules/Oculus/XRTK.Oculus/Packages/com.xrtk.oculus/Profiles~

--- a/XRTK-Core/Assets/XRTK.Generated/Oculus/Profiles.meta
+++ b/XRTK-Core/Assets/XRTK.Generated/Oculus/Profiles.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 9559e031c4b68bc49914128d51c62d36
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/XRTK-Core/Assets/XRTK.Generated/SDK.meta
+++ b/XRTK-Core/Assets/XRTK.Generated/SDK.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b38393cce99e65144a83b16dad306c97
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/XRTK-Core/Assets/XRTK.Generated/SDK/Prefabs
+++ b/XRTK-Core/Assets/XRTK.Generated/SDK/Prefabs
@@ -1,1 +1,0 @@
-../../../../Submodules/SDK/XRTK.SDK/Packages/com.xrtk.sdk/Prefabs~

--- a/XRTK-Core/Assets/XRTK.Generated/SDK/Prefabs.meta
+++ b/XRTK-Core/Assets/XRTK.Generated/SDK/Prefabs.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3014914e6a851f64cab2f58b7354a087
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/XRTK-Core/Assets/XRTK.Generated/SDK/Profiles
+++ b/XRTK-Core/Assets/XRTK.Generated/SDK/Profiles
@@ -1,1 +1,0 @@
-../../../../Submodules/SDK/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~

--- a/XRTK-Core/Assets/XRTK.Generated/SDK/Profiles.meta
+++ b/XRTK-Core/Assets/XRTK.Generated/SDK/Profiles.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 38d3a1bf99e6e9c46a5fff84b8ecc9ee
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/XRTK-Core/Assets/XRTK.Generated/Ultraleap.meta
+++ b/XRTK-Core/Assets/XRTK.Generated/Ultraleap.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: eaf3078a68c648243822040be684ecdd
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/XRTK-Core/Assets/XRTK.Generated/Ultraleap/Profiles
+++ b/XRTK-Core/Assets/XRTK.Generated/Ultraleap/Profiles
@@ -1,1 +1,0 @@
-../../../../Submodules/Ultraleap/XRTK.Ultraleap/Packages/com.xrtk.ultraleap/Profiles~

--- a/XRTK-Core/Assets/XRTK.Generated/Ultraleap/Profiles.meta
+++ b/XRTK-Core/Assets/XRTK.Generated/Ultraleap/Profiles.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b8cc049b846502b4ea39f2ef0b570cac
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/XRTK-Core/Assets/XRTK.Generated/WindowsMixedReality.meta
+++ b/XRTK-Core/Assets/XRTK.Generated/WindowsMixedReality.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 5c966c48ad294b84ba04de9e46ae6213
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/XRTK-Core/Assets/XRTK.Generated/WindowsMixedReality/Profiles
+++ b/XRTK-Core/Assets/XRTK.Generated/WindowsMixedReality/Profiles
@@ -1,1 +1,0 @@
-../../../../Submodules/WindowsMixedReality/XRTK.WindowsMixedReality/Packages/com.xrtk.wmr/Profiles~

--- a/XRTK-Core/Assets/XRTK.Generated/WindowsMixedReality/Profiles.meta
+++ b/XRTK-Core/Assets/XRTK.Generated/WindowsMixedReality/Profiles.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 5cfba1e03ef51944281a9ef53b866e01
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->

In some circumstances, the cached symlink files can cause issues on machines by becoming read-only, this causes issues such as identified in #916 
As the Symlinks are intended to be autogenerated links from other sources, these cached files are not needed.

The GitIgnore file has been updated to ensure these links are not added again.

Any required changes to the XRTK.Generated folder should be manually added in the future.

## Changes
<!-- Brief list of the targeted features that are being changed. -->

- Fixes: [<!--issue number or url-->](https://github.com/XRTK/com.xrtk.core/issues/916)

## Breaking Changes
<!--  Are there any breaking changes included in this change that would prevent or cause issue for existing projects? -->
None