### PR TITLE
Updated Camera validation

### DIFF
--- a/XRTK-Core/Packages/com.xrtk.core/Editor/MixedRealityToolkitInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/MixedRealityToolkitInspector.cs
@@ -224,6 +224,12 @@ namespace XRTK.Editor
                     Debug.Assert(!string.IsNullOrWhiteSpace(activeScene.path), "Configured Scene must be saved in order to set it as the Start Scene!\n" + "Please save your scene and set it as the Start Scene in the XRTK preferences.");
                     MixedRealityPreferences.StartSceneAsset = AssetDatabase.LoadAssetAtPath<SceneAsset>(activeScene.path);
                 }
+
+                if (XRTK.Utilities.CameraCache.Main.transform.parent.IsNull())
+                {
+                    var rigTransform = new GameObject("XRCameraRig").transform;
+                    XRTK.Utilities.CameraCache.Main.transform.SetParent(rigTransform);
+                }
             }
             catch (Exception e)
             {

--- a/XRTK-Core/Packages/com.xrtk.core/Editor/MixedRealityToolkitInspector.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Editor/MixedRealityToolkitInspector.cs
@@ -224,12 +224,6 @@ namespace XRTK.Editor
                     Debug.Assert(!string.IsNullOrWhiteSpace(activeScene.path), "Configured Scene must be saved in order to set it as the Start Scene!\n" + "Please save your scene and set it as the Start Scene in the XRTK preferences.");
                     MixedRealityPreferences.StartSceneAsset = AssetDatabase.LoadAssetAtPath<SceneAsset>(activeScene.path);
                 }
-
-                if (XRTK.Utilities.CameraCache.Main.transform.parent.IsNull())
-                {
-                    var rigTransform = new GameObject("XRCameraRig").transform;
-                    XRTK.Utilities.CameraCache.Main.transform.SetParent(rigTransform);
-                }
             }
             catch (Exception e)
             {

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
@@ -308,7 +308,7 @@ namespace XRTK.Providers.CameraSystem
             cameraSystem.UnRegisterCameraDataProvider(this);
         }
 
-#endregion IMixedRealitySerivce Implementation
+        #endregion IMixedRealitySerivce Implementation
 
         private void EnsureCameraRigSetup()
         {

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
@@ -168,8 +168,8 @@ namespace XRTK.Providers.CameraSystem
 #if XRTK_USE_LEGACYVR
             ApplySettingsForDefaultHeadHeight();
 #else
-            // We attempt to intialize the camera tracking origin, which might
-            // fail at this point if the subystems are not ready, in which case,
+            // We attempt to initialize the camera tracking origin, which might
+            // fail at this point if the subsytems are not ready, in which case,
             // we set a flag to keep trying.
             trackingOriginInitialized = SetupTrackingOrigin();
             trackingOriginInitializing = !trackingOriginInitialized;
@@ -245,9 +245,9 @@ namespace XRTK.Providers.CameraSystem
             }
 
 #if !XRTK_USE_LEGACYVR
-            // We keep trying to intiailze the tracking origin,
+            // We keep trying to initialize the tracking origin,
             // until it worked, because at application launch the
-            // subystems might not be ready yet.
+            // subsytems might not be ready yet.
             if (trackingOriginInitializing && !trackingOriginInitialized)
             {
                 trackingOriginInitialized = SetupTrackingOrigin();

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
@@ -341,14 +341,20 @@ namespace XRTK.Providers.CameraSystem
             {
                 for (int i = 0; i < inputSubsystems.Count; i++)
                 {
-                    var result = SetupTrackingOrigin(inputSubsystems[i]);
-                    if (result)
+                    if (inputSubsystems[i].SubsystemDescriptor.id == "MockHMD Head Tracking")
                     {
-                        inputSubsystems[i].trackingOriginUpdated -= XRInputSubsystem_OnTrackingOriginUpdated;
-                        inputSubsystems[i].trackingOriginUpdated += XRInputSubsystem_OnTrackingOriginUpdated;
+                        UpdateCameraHeightOffset(defaultHeadHeight);
                     }
-
-                    trackingOriginModeSet &= result;
+                    else
+                    {
+                        var result = SetupTrackingOrigin(inputSubsystems[i]);
+                        if (result)
+                        {
+                            inputSubsystems[i].trackingOriginUpdated -= XRInputSubsystem_OnTrackingOriginUpdated;
+                            inputSubsystems[i].trackingOriginUpdated += XRInputSubsystem_OnTrackingOriginUpdated;
+                        }
+                        trackingOriginModeSet &= result;
+                    }
                 }
             }
             else

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Providers/CameraSystem/BaseCameraDataProvider.cs
@@ -316,7 +316,7 @@ namespace XRTK.Providers.CameraSystem
             {
                 if (CameraCache.Main.transform.parent.IsNull())
                 {
-                    var rigTransform = new GameObject().transform;
+                    var rigTransform = new GameObject(MixedRealityToolkit.DefaultXRCameraRigName).transform;
                     CameraCache.Main.transform.SetParent(rigTransform);
                 }
 
@@ -420,7 +420,7 @@ namespace XRTK.Providers.CameraSystem
             SyncRigTransforms();
         }
 
-#endregion Tracking Origin Setup
+        #endregion Tracking Origin Setup
 #endif
 
 #if XRTK_USE_LEGACYVR

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
@@ -229,7 +229,8 @@ namespace XRTK.Services.CameraSystem
                 bodyTransform.name = playerBodyName;
             }
 
-            if (playerCamera != null && playerCamera.transform.parent.name != rigName)
+
+            if (PlayerCamera.transform.parent.name != rigName)
             {
                 // Since the scene is set up with a different camera parent, its likely
                 // that there's an expectation that that parent is going to be used for
@@ -238,7 +239,7 @@ namespace XRTK.Services.CameraSystem
                 // might cause conflicts with the parent's intended purpose.
                 Debug.LogWarning($"The Mixed Reality Toolkit expected the camera\'s parent to be named {rigName}. The existing parent will be renamed and used instead.");
                 // If we rename it, we make it clearer that why it's being teleported around at runtime.
-                playerCamera.transform.parent.name = rigName;
+                PlayerCamera.transform.parent.name = rigName;
             }
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
@@ -19,7 +19,7 @@ namespace XRTK.Services.CameraSystem
         #region IMixedRealityCameraRig Implementation
 
         [SerializeField]
-        private string rigName = "XRCameraRig";
+        private string rigName = MixedRealityToolkit.DefaultXRCameraRigName;
 
         [SerializeField]
         private Transform rigTransform = null;

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
@@ -115,18 +115,6 @@ namespace XRTK.Services.CameraSystem
                 }
                 else
                 {
-                    if (playerCamera.transform.parent.name != rigName)
-                    {
-                        // Since the scene is set up with a different camera parent, its likely
-                        // that there's an expectation that that parent is going to be used for
-                        // something else. We print a warning to call out the fact that we're
-                        // co-opting this object for use with teleporting and such, since that
-                        // might cause conflicts with the parent's intended purpose.
-                        Debug.LogWarning($"The Mixed Reality Toolkit expected the camera\'s parent to be named {rigName}. The existing parent will be renamed and used instead.");
-                        // If we rename it, we make it clearer that why it's being teleported around at runtime.
-                        playerCamera.transform.parent.name = rigName;
-                    }
-
                     rigTransform = playerCamera.transform.parent;
                 }
 
@@ -239,6 +227,18 @@ namespace XRTK.Services.CameraSystem
                 !bodyTransform.name.Equals(playerBodyName))
             {
                 bodyTransform.name = playerBodyName;
+            }
+
+            if (playerCamera != null && playerCamera.transform.parent.name != rigName)
+            {
+                // Since the scene is set up with a different camera parent, its likely
+                // that there's an expectation that that parent is going to be used for
+                // something else. We print a warning to call out the fact that we're
+                // co-opting this object for use with teleporting and such, since that
+                // might cause conflicts with the parent's intended purpose.
+                Debug.LogWarning($"The Mixed Reality Toolkit expected the camera\'s parent to be named {rigName}. The existing parent will be renamed and used instead.");
+                // If we rename it, we make it clearer that why it's being teleported around at runtime.
+                playerCamera.transform.parent.name = rigName;
             }
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
@@ -229,7 +229,6 @@ namespace XRTK.Services.CameraSystem
                 bodyTransform.name = playerBodyName;
             }
 
-
             if (PlayerCamera.transform.parent.name != rigName)
             {
                 // Since the scene is set up with a different camera parent, its likely
@@ -237,7 +236,7 @@ namespace XRTK.Services.CameraSystem
                 // something else. We print a warning to call out the fact that we're
                 // co-opting this object for use with teleporting and such, since that
                 // might cause conflicts with the parent's intended purpose.
-                Debug.LogWarning($"The Mixed Reality Toolkit expected the camera\'s parent to be named {rigName}. The existing parent will be renamed and used instead.");
+                Debug.LogWarning($"The Mixed Reality Toolkit expected the camera\'s parent to be named {rigName}. The existing parent will be renamed and used instead.\nPlease ensure youe scene is configured properly in the editor using \'MixedRealityToolkit -> Configure..\'");
                 // If we rename it, we make it clearer that why it's being teleported around at runtime.
                 PlayerCamera.transform.parent.name = rigName;
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/CameraSystem/DefaultCameraRig.cs
@@ -118,8 +118,6 @@ namespace XRTK.Services.CameraSystem
                     rigTransform = playerCamera.transform.parent;
                 }
 
-                Debug.Assert(CameraPoseDriver != null);
-
                 return playerCamera;
             }
         }
@@ -149,6 +147,9 @@ namespace XRTK.Services.CameraSystem
 #else
                 cameraPoseDriver.UseRelativeTransform = false;
 #endif
+
+                Debug.Assert(cameraPoseDriver != null);
+
                 return cameraPoseDriver;
             }
         }
@@ -193,28 +194,6 @@ namespace XRTK.Services.CameraSystem
 
         #region MonoBehaviour Implementation
 
-        private void Start()
-        {
-            if (MixedRealityToolkit.TryGetSystem<IMixedRealityCameraSystem>(out var cameraSystem)
-                && CameraPoseDriver.IsNotNull())
-            {
-                switch (cameraSystem.TrackingType)
-                {
-                    case TrackingType.SixDegreesOfFreedom:
-                        CameraPoseDriver.trackingType = TrackedPoseDriver.TrackingType.RotationAndPosition;
-                        break;
-                    case TrackingType.ThreeDegreesOfFreedom:
-                        CameraPoseDriver.trackingType = TrackedPoseDriver.TrackingType.RotationOnly;
-                        break;
-                    case TrackingType.Auto:
-                    default:
-                        // For now, leave whatever the user has confitured manually on the component. Once we
-                        // have APIs in place to querey platform capabilities, we might use that for auto.
-                        break;
-                }
-            }
-        }
-
         private void OnValidate()
         {
             if (rigTransform != null &&
@@ -239,6 +218,28 @@ namespace XRTK.Services.CameraSystem
                 Debug.LogWarning($"The Mixed Reality Toolkit expected the camera\'s parent to be named {rigName}. The existing parent will be renamed and used instead.\nPlease ensure youe scene is configured properly in the editor using \'MixedRealityToolkit -> Configure..\'");
                 // If we rename it, we make it clearer that why it's being teleported around at runtime.
                 PlayerCamera.transform.parent.name = rigName;
+            }
+        }
+
+        private void Start()
+        {
+            if (MixedRealityToolkit.TryGetSystem<IMixedRealityCameraSystem>(out var cameraSystem)
+                && CameraPoseDriver.IsNotNull())
+            {
+                switch (cameraSystem.TrackingType)
+                {
+                    case TrackingType.SixDegreesOfFreedom:
+                        CameraPoseDriver.trackingType = TrackedPoseDriver.TrackingType.RotationAndPosition;
+                        break;
+                    case TrackingType.ThreeDegreesOfFreedom:
+                        CameraPoseDriver.trackingType = TrackedPoseDriver.TrackingType.RotationOnly;
+                        break;
+                    case TrackingType.Auto:
+                    default:
+                        // For now, leave whatever the user has configured manually on the component. Once we
+                        // have APIs in place to query platform capabilities, we might use that for auto.
+                        break;
+                }
             }
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/LocomotionSystem/LocomotionSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/LocomotionSystem/LocomotionSystem.cs
@@ -91,7 +91,7 @@ namespace XRTK.Services.LocomotionSystem
         /// <inheritdoc />
         public override void Destroy()
         {
-            if (Camera.main != null)
+            if (CameraCache.IsNotNull)
             {
                 CameraCache.Main.gameObject.EnsureComponentDestroyed<LocomotionProviderEventDriver>();
             }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/LocomotionSystem/LocomotionSystem.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/LocomotionSystem/LocomotionSystem.cs
@@ -91,7 +91,10 @@ namespace XRTK.Services.LocomotionSystem
         /// <inheritdoc />
         public override void Destroy()
         {
-            CameraCache.Main.gameObject.EnsureComponentDestroyed<LocomotionProviderEventDriver>();
+            if (Camera.main != null)
+            {
+                CameraCache.Main.gameObject.EnsureComponentDestroyed<LocomotionProviderEventDriver>();
+            }
             base.Destroy();
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
@@ -122,8 +122,15 @@ namespace XRTK.Services
                 DestroyAllServices();
             }
 
-            EnsureMixedRealityRequirements();
-            InitializeServiceLocator();
+            if (HasActiveProfile)
+            {
+                EnsureMixedRealityRequirements();
+                InitializeServiceLocator();
+            }
+            else
+            {
+                Debug.LogError("Unable to restart Toolkit as no profile was found");
+            }
 
             isResetting = false;
         }
@@ -316,10 +323,11 @@ namespace XRTK.Services
                 }
 #endif // UNITY_EDITOR
 
-                EnsureMixedRealityRequirements();
-
+                // if the Toolit has a profile, validate toolkit requirements and initialise services
                 if (HasActiveProfile)
                 {
+                    EnsureMixedRealityRequirements();
+
                     InitializeServiceLocator();
                 }
             }
@@ -530,8 +538,21 @@ namespace XRTK.Services
             // We'll enforce that here, then tracking can update it to the appropriate position later.
             CameraCache.Main.transform.position = Vector3.zero;
 
+            // Validate the CameraRig is setup with the main camera as a child of the rig
+            EnsureCameraRig();
+
             // We need at least one instance of the event system to be active.
             EnsureEventSystemSetup();
+        }
+
+        private static void EnsureCameraRig()
+        {
+            if (CameraCache.Main.transform.parent.IsNull())
+            {
+                var rigTransform = new GameObject("XRCameraRig").transform;
+                CameraCache.Main.transform.SetParent(rigTransform);
+                Debug.Log($"There was no XRCameraRig in the scene. The {nameof(MixedRealityToolkit)} requires one and added it, as well as making the main camera a child of the rig.");
+            }
         }
 
         private static void EnsureEventSystemSetup()

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
@@ -49,6 +49,8 @@ namespace XRTK.Services
             }
         }
 
+        public static string DefaultXRCameraRigName = "XRCameraRig";
+
         /// <summary>
         /// The active profile of the Mixed Reality Toolkit which controls which services are active and their initial settings.
         /// *Note a profile is used on project initialization or replacement, changes to properties while it is running has no effect.
@@ -542,9 +544,9 @@ namespace XRTK.Services
         {
             if (CameraCache.Main.transform.parent.IsNull())
             {
-                var rigTransform = new GameObject("XRCameraRig").transform;
+                var rigTransform = new GameObject(MixedRealityToolkit.DefaultXRCameraRigName).transform;
                 CameraCache.Main.transform.SetParent(rigTransform);
-                Debug.Log($"There was no XRCameraRig in the scene. The {nameof(MixedRealityToolkit)} requires one and added it, as well as making the main camera a child of the rig.");
+                Debug.Log($"There was no {MixedRealityToolkit.DefaultXRCameraRigName} in the scene. The {nameof(MixedRealityToolkit)} requires one and added it, as well as making the main camera a child of the rig.");
             }
         }
 

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Services/MixedRealityToolkit.cs
@@ -122,15 +122,8 @@ namespace XRTK.Services
                 DestroyAllServices();
             }
 
-            if (HasActiveProfile)
-            {
-                EnsureMixedRealityRequirements();
-                InitializeServiceLocator();
-            }
-            else
-            {
-                Debug.LogError("Unable to restart Toolkit as no profile was found");
-            }
+            EnsureMixedRealityRequirements();
+            InitializeServiceLocator();
 
             isResetting = false;
         }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Utilities/CameraCache.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Utilities/CameraCache.cs
@@ -52,5 +52,21 @@ namespace XRTK.Utilities
 
             return cachedCamera = newMain;
         }
+
+        /// <summary>
+        /// Validates if the CameraCache reference is Null to avoid creating a new camera if it does not exist.
+        /// </summary>
+        public static bool IsNull
+        {
+            get { return Camera.main == null || cachedCamera == null; }
+        }
+
+        /// <summary>
+        /// Validates if the CameraCache reference is Null to avoid creating a new camera if it does not exist.
+        /// </summary>
+        public static bool IsNotNull
+        {
+            get { return !IsNull; }
+        }
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Utilities/CameraCache.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Utilities/CameraCache.cs
@@ -54,19 +54,13 @@ namespace XRTK.Utilities
         }
 
         /// <summary>
-        /// Validates if the CameraCache reference is Null to avoid creating a new camera if it does not exist.
+        /// Validates if both the CameraCache reference as well as <see cref="Camera.main"/> is Null to avoid creating a new camera if it does not exist.
         /// </summary>
-        public static bool IsNull
-        {
-            get { return Camera.main == null || cachedCamera == null; }
-        }
+        public static bool IsNull => Camera.main == null || cachedCamera == null;
 
         /// <summary>
-        /// Validates if the CameraCache reference is Not Null to avoid creating a new camera if it does not exist.
+        /// Validates if both the CameraCache reference as well as <see cref="Camera.main"/> is NotNull to avoid creating a new camera if it does not exist.
         /// </summary>
-        public static bool IsNotNull
-        {
-            get { return !IsNull; }
-        }
+        public static bool IsNotNull => !IsNull;
     }
 }

--- a/XRTK-Core/Packages/com.xrtk.core/Runtime/Utilities/CameraCache.cs
+++ b/XRTK-Core/Packages/com.xrtk.core/Runtime/Utilities/CameraCache.cs
@@ -62,7 +62,7 @@ namespace XRTK.Utilities
         }
 
         /// <summary>
-        /// Validates if the CameraCache reference is Null to avoid creating a new camera if it does not exist.
+        /// Validates if the CameraCache reference is Not Null to avoid creating a new camera if it does not exist.
         /// </summary>
         public static bool IsNotNull
         {


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->

Updated the camera validation and regeneration as a result of #911 

## Changes
<!-- Brief list of the targeted features that are being changed. -->

* Moved Camera validation routines to "OnEnable" in the Camera Provider
* Moved Rig Validation to the OnValidate method, so it is checked at the right time
* Added Rig Validation to the Toolkit Validation methods
* Ensured Toolkit validation ONLY occurs when a profile has been assigned
* Fixed a random bug whereby CameraCache was being called in OnDestroy without first checking there was a camera to destroy (as it created a new camera)
* Updated validation warnings

Tested all scenarios where the scene will be validated:

* New Scene
* New Scene + Configure
* New GO + Toolkit object
* Deleting Toolkit and readding
* Deleting Rig and checking configuration

Fixes: 
- https://github.com/XRTK/com.xrtk.core/issues/911

## Breaking Changes
<!--  Are there any breaking changes included in this change that would prevent or cause issue for existing projects? -->

None
