### PR TITLE
Reset XR loader configuration as it was producing unintended results

### DIFF
--- a/XRTK-Core/Assets/XR/XRGeneralSettings.asset
+++ b/XRTK-Core/Assets/XR/XRGeneralSettings.asset
@@ -16,6 +16,36 @@ MonoBehaviour:
   m_AutomaticLoading: 0
   m_AutomaticRunning: 0
   m_Loaders: []
+--- !u!114 &-8200192391502015879
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4c3631f5e58749a59194e0cf6baf6d5, type: 3}
+  m_Name: iPhone Providers
+  m_EditorClassIdentifier: 
+  m_RequiresSettingsUpdate: 0
+  m_AutomaticLoading: 0
+  m_AutomaticRunning: 0
+  m_Loaders: []
+--- !u!114 &-7628137627269530181
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
+  m_Name: iPhone Settings
+  m_EditorClassIdentifier: 
+  m_LoaderManagerInstance: {fileID: -8200192391502015879}
+  m_InitManagerOnStart: 1
 --- !u!114 &-5842413985860741297
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31,8 +61,7 @@ MonoBehaviour:
   m_RequiresSettingsUpdate: 0
   m_AutomaticLoading: 0
   m_AutomaticRunning: 0
-  m_Loaders:
-  - {fileID: 11400000, guid: a3b5ed70886f05e46941d4c937e02437, type: 2}
+  m_Loaders: []
 --- !u!114 &-5810052535269155685
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -48,8 +77,7 @@ MonoBehaviour:
   m_RequiresSettingsUpdate: 0
   m_AutomaticLoading: 0
   m_AutomaticRunning: 0
-  m_Loaders:
-  - {fileID: 11400000, guid: 4e75234349cacc74c887df28234088a1, type: 2}
+  m_Loaders: []
 --- !u!114 &-5075777558928976932
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -79,8 +107,7 @@ MonoBehaviour:
   m_RequiresSettingsUpdate: 0
   m_AutomaticLoading: 0
   m_AutomaticRunning: 0
-  m_Loaders:
-  - {fileID: 11400000, guid: 4e75234349cacc74c887df28234088a1, type: 2}
+  m_Loaders: []
 --- !u!114 &-1889517401308975564
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -124,13 +151,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2dc886499c26824283350fa532d087d, type: 3}
   m_Name: XRGeneralSettings
   m_EditorClassIdentifier: 
-  Keys: 0e000000010000001c000000070000000d000000
+  Keys: 0e000000010000001c000000070000000d00000004000000
   Values:
   - {fileID: 7843802771899202064}
   - {fileID: -5075777558928976932}
   - {fileID: 7291748261543734245}
   - {fileID: -115329935226179108}
   - {fileID: 1311891893792666627}
+  - {fileID: -7628137627269530181}
 --- !u!114 &1311891893792666627
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/XRTK-Core/ProjectSettings/EditorBuildSettings.asset
+++ b/XRTK-Core/ProjectSettings/EditorBuildSettings.asset
@@ -9,6 +9,8 @@ EditorBuildSettings:
     path: Assets/XRTK.Examples/BaseScene.unity
     guid: 092b39bb8f12afa498a539bd456a71d6
   m_configObjects:
+    Unity.XR.Oculus.Settings: {fileID: 11400000, guid: c4982dfe119d0264490af5c151c3827a,
+      type: 2}
     Unity.XR.WindowsMR.Settings: {fileID: 11400000, guid: c1ab88c6e8137d949b3ba9d7c77ff5eb,
       type: 2}
     com.unity.xr.magicleap.magic_leap_settings: {fileID: 11400000, guid: bf4ca4b201eff6f47bfcf89c2053db39,


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->

Disabled and updated Unity XR loader configuration back to original XRTK settings

## Changes
<!-- Brief list of the targeted features that are being changed. -->

Turns off all XR loaders by default and updates settings based on current layout.  Developers should only enable loaders in development for those they are testing with.